### PR TITLE
Av/platformio support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,41 @@
 build
+
+# Compiled Object files
+*.slo
+*.lo
+*.o
+*.obj
+
+# Precompiled Headers
+*.gch
+*.pch
+
+# Compiled Dynamic libraries
+*.so
+*.dylib
+*.dll
+
+# Compiled Static libraries
+*.lai
+*.la
+*.a
+*.lib
+
+# Executables
+*.exe
+*.out
+*.app
+
+# Vim backups
+*.swp
+
+# travis
+.travis.yml
+
+# PlatformIO work files
+.pio
+.pioenvs
+.piolibdeps
+*tags*
+
+

--- a/library.json
+++ b/library.json
@@ -1,7 +1,7 @@
 {
-  "name": "MATRIX Voice HAL for ESP32",
-  "keywords": "hal, drivers, matrixvoice, everloop, mic, micarray",
-  "description": "This is the official set of ESP-IDF components for MATRIX Voice.",
+  "name": "MATRIXVoiceESP32HAL",
+  "keywords": "hal, drivers, matrixvoice, everloop, mic, micarray, espressif, esp32",
+  "description": "MatrixVoice HAL library. ESP-IDF components",
   "homepage": "https://www.matrix.one/products/voice",
   "repository": {
     "type": "git",

--- a/library.json
+++ b/library.json
@@ -12,7 +12,7 @@
     "name": "Matrix One",
     "url": "https://www.matrix.one"
   },
-  "srcDir":"components",
+  "srcDir":"components/hal",
   "frameworks": "arduino",
   "platforms": "*"
 }

--- a/library.json
+++ b/library.json
@@ -14,7 +14,7 @@
   },
   "build":{
     "srcDir":"components/hal",
-  }
+  },
   "frameworks": "arduino",
   "platforms": "*"
 }

--- a/library.json
+++ b/library.json
@@ -13,7 +13,7 @@
     "url": "https://www.matrix.one"
   },
   "build":{
-    "srcDir":"components/hal",
+    "srcDir":"components/hal"
   },
   "frameworks": "arduino",
   "platforms": "*"

--- a/library.json
+++ b/library.json
@@ -10,7 +10,7 @@
   "version": "0.77.0",
   "authors": [
     {
-      "name": "Matrix One",
+      "name": "MATRIX Labs",
       "url": "https://www.matrix.one"
     },
     {

--- a/library.json
+++ b/library.json
@@ -8,10 +8,18 @@
     "url": "https://github.com/matrix-io/matrixio_hal_esp32"
   },
   "version": "0.77.0",
-  "authors": {
-    "name": "Matrix One",
-    "url": "https://www.matrix.one"
-  },
+  "authors": [
+    {
+      "name": "Matrix One",
+      "url": "https://www.matrix.one"
+    },
+    {
+      "name": "@hpsaturn",
+      "email": "hpsaturn@gmail.com",
+      "url": "http://hpsaturn.com",
+      "maintainer": true
+    }
+  ],
   "build":{
     "srcDir":"components/hal"
   },

--- a/library.json
+++ b/library.json
@@ -12,7 +12,9 @@
     "name": "Matrix One",
     "url": "https://www.matrix.one"
   },
-  "srcDir":"components/hal",
+  "build":{
+    "srcDir":"components/hal",
+  }
   "frameworks": "arduino",
   "platforms": "*"
 }

--- a/library.json
+++ b/library.json
@@ -1,0 +1,18 @@
+{
+  "name": "MATRIX Voice HAL for ESP32",
+  "keywords": "hal, drivers, matrixvoice, everloop, mic, micarray",
+  "description": "This is the official set of ESP-IDF components for MATRIX Voice.",
+  "homepage": "https://www.matrix.one/products/voice",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/matrix-io/matrixio_hal_esp32"
+  },
+  "version": "0.77.0",
+  "authors": {
+    "name": "Matrix One",
+    "url": "https://www.matrix.one"
+  },
+  "srcDir":"components",
+  "frameworks": "arduino",
+  "platforms": "*"
+}


### PR DESCRIPTION
Added [PlatformIO](https://platformio.org/) library manager support. PlatformIO is an open source ecosystem for IoT development, with this registry we have support for build Matrixio ESP32 OTA library with it.

Please validate or comment the "authors" section and Matrixone urls, etc.
